### PR TITLE
Implement parfor for PFM and allow to set up number of workers in iCAPs

### DIFF
--- a/functions/01_TotalActivation/RunTotalActivation.m
+++ b/functions/01_TotalActivation/RunTotalActivation.m
@@ -105,7 +105,6 @@ function [TC_OUT,param] = RunTotalActivation(TCN,param)
             % param.use_pfm==1, otherwise use the temporal regularization in Total Activation
             if (param.use_pfm==1)
                 fprintf('Launching MyTemporal with Paradigm Free Mapping\n');
-                param.use_parfor=0;
                 tmt = toc;
                 [temp,Activity_inducing,Innovation, param] = MyTemporal_pfm(TC_IN, param);
                 fprintf('PFM completed in %.5f\n', toc-tmt);

--- a/functions/01_TotalActivation/Spatial_TA/TA_Spatial_Graph.m
+++ b/functions/01_TotalActivation/Spatial_TA/TA_Spatial_Graph.m
@@ -37,19 +37,15 @@ function x_out = TA_Spatial_Graph(y,param)
 
 
 x_out = zeros(size(y)); % out
-if (param.use_parfor==1)
-    if(isempty(gcp('nocreate')) && param.use_parfor)
+if (param.parfor_w>=1)
+    if(isempty(gcp('nocreate')))
 	    parpool(24)
 	else
         p=gcp;
         fprintf('There are %d workers in pool.\n', p.NumWorkers);
     end
-    parfor t=1:param.Dimension(4)
-        x_out(t,:) =MyProx_graph(y(t,:),param);
-    end
-else
-    for t=1:param.Dimension(4)
-        x_out(t,:) =MyProx_graph(y(t,:),param);
-    end
+end
+parfor (t=1:param.Dimension(4),param.parfor_w)
+    x_out(t,:) =MyProx_graph(y(t,:),param);
 end
 end

--- a/functions/01_TotalActivation/Temporal_PFM/PFM_Temporal_OneTimeCourse.m
+++ b/functions/01_TotalActivation/Temporal_PFM/PFM_Temporal_OneTimeCourse.m
@@ -13,10 +13,9 @@
 % - ParametersOut: structure containing the parameters of the algorithm
 %
 % Implemented by Eneko Uruñuela, 13.12.2022
-function [Activity_related,Activity_inducing,Innovation,ParametersOut] = TA_Temporal_OneTimeCourse(y,idx_vox,ParametersIn)
+function [Activity_related,Activity_inducing,Innovation,NoiseEstimateFin,LambdasTempFin] = TA_Temporal_OneTimeCourse(y,idx_vox,ParametersIn)
 
     % The necessary HRF matrices are computed
-    ParametersOut = ParametersIn;
     X_tilde = ParametersIn.HRF;
     X_tilde_trans = ParametersIn.X_tilde_trans;
     X_tilde_tt = ParametersIn.X_tilde_tt;
@@ -138,8 +137,8 @@ function [Activity_related,Activity_inducing,Innovation,ParametersOut] = TA_Temp
     % Stores, for the considered voxel, the final noise estimate that was made,
     % and the final related regularisation parameter, so that if we re-enter
     % Temporal_TA, they are directly used as initial estimate
-    ParametersOut.NoiseEstimateFin = nv(end);
-    ParametersOut.LambdasTempFin = Lambda(end);
+    NoiseEstimateFin = nv(end);
+    LambdasTempFin = Lambda(end);
 
 end
 


### PR DESCRIPTION
I modify the different functions so parfor is executed based on ``param.parfor_w`` if this parameter is bigger than 1 then a parpool will be open and both pfm and TA will use this parpool for their processes